### PR TITLE
Update index.php

### DIFF
--- a/view/index.php
+++ b/view/index.php
@@ -289,7 +289,7 @@ if (!empty($_GET['noNavbar'])) {
                                         ?>
                                         <div class="input-group input-group-sm">
                                             <span class="input-group-addon"><?php echo $value['name']; ?></span>
-                                            <input type="text" class="form-control formats" placeholder="Code" id="format_<?php echo $value['id']; ?>" value="<?php echo $value['code']; ?>">
+                                            <input type="text" class="form-control formats" placeholder="Code" id="format_<?php echo $value['id']; ?>" value="<?php echo htmlentities($value['code']); ?>">
                                         </div>    
                                         <?php
                                     }


### PR DESCRIPTION
change:
$value['code'] => htmlentities($value['code'])


if the double quotation mark character is used in the configuration, the settings are not saved correctly.
Example:
replacing in the ffmpeg configuration:
scale = -2: 540 => "scale = -2: 'min (540, ih)'"
the rescue is not successful