### PR TITLE
Update objects/Format.php and view/index.php

### DIFF
--- a/objects/Format.php
+++ b/objects/Format.php
@@ -315,7 +315,7 @@ res{$value}/index.m3u8
 
 
 
-            eval('$code ="' . $fc . '";');
+            eval('$code ="' . addcslashes($fc,'"') . '";');
             if (empty($code)) {
                 $obj->msg = "Code not found ($format_id, $pathFileName, $destinationFile, $encoder_queue_id)";
             } else {

--- a/view/index.php
+++ b/view/index.php
@@ -289,7 +289,7 @@ if (!empty($_GET['noNavbar'])) {
                                         ?>
                                         <div class="input-group input-group-sm">
                                             <span class="input-group-addon"><?php echo $value['name']; ?></span>
-                                            <input type="text" class="form-control formats" placeholder="Code" id="format_<?php echo $value['id']; ?>" value="<?php echo $value['code']; ?>">
+                                            <input type="text" class="form-control formats" placeholder="Code" id="format_<?php echo $value['id']; ?>" value="<?php echo htmlentities($value['code']); ?>">
                                         </div>    
                                         <?php
                                     }


### PR DESCRIPTION
change in view/index.php (line 292):

$value['code'] => htmlentities($value['code'])

if the double quotation mark character is used in the configuration, the settings are not saved correctly.
Example:
replacing in the ffmpeg configuration:
scale = -2: 540 => "scale = -2: 'min (540, ih)'"
the rescue is not successful






change in objects/Format.php (line 318):

eval('$code ="' .$fc . '";'); 
to
eval('$code ="' . addcslashes($fc,'"') . '";');


if in the code there is double quote char, it is must escaped




